### PR TITLE
replace isinstance() with type()

### DIFF
--- a/cn_stock_holidays/meta_functions.py
+++ b/cn_stock_holidays/meta_functions.py
@@ -203,7 +203,7 @@ def meta_is_trading_day(get_cached):
         if dt is None:
             raise TypeError("Date cannot be None")
 
-        if not isinstance(dt, (datetime.date, datetime.datetime)):
+        if not ((type(dt) is datetime.date) or (type(dt) is datetime.datetime)):
             raise TypeError("Date must be datetime.date or datetime.datetime")
 
         if type(dt) is datetime.datetime:


### PR DESCRIPTION
以2026年后第一个交易日2026-02-24为例，在尝试把 pd.Timestamp.now() 传入 previous_trading_day 获得前一个交易日的时候产生了预期外的结果：
```python
# test.py
from cn_stock_holidays.data import previous_trading_day
import pandas as pd

now = pd.Timestamp.now()
print(now)
print(previous_trading_day(now))
```
```sh
python test.py
2026-02-24 10:42:26.032174
2026-02-23 10:42:26.032174
```
找了一下原因，发现是 pd.Timestamp 继承了 datetime.datetime，所以在 previous_trading_day 函数中 `if type(dt) is datetime.datetime` 判断为 False，所以没有执行 `dt = dt.date()` 就传入了 is_trading_day 函数
https://github.com/rainx/cn_stock_holidays/blob/15837ba83ae9f33461a30a23d1367d0dd58846f7/cn_stock_holidays/meta_functions.py#L250-L260
而在 is_trading_day 函数中，由于 pd.Timestamp 继承自 datetime.datetime，导致 `isinstance(dt, (datetime.date, datetime.datetime))` 判断为 True，因此没有类型报错，同时 `if type(dt) is datetime.datetime` 判断为 False，最后 `if dt in holidays` 判断为 False 导致返回2026-02-23 10:42:26.032174
https://github.com/rainx/cn_stock_holidays/blob/15837ba83ae9f33461a30a23d1367d0dd58846f7/cn_stock_holidays/meta_functions.py#L201-L219

建议：在 is_trading_day 函数的类型检测中增强限制，把
`if not isinstance(dt, (datetime.date, datetime.datetime))`
改为
`if not ((type(dt) is datetime.date) or (type(dt) is datetime.datetime))`